### PR TITLE
Update integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ cabal v2-run nix-shell-bit-test \
     --rerun
 ```
 
+integration tests
+```sh
+test/integration
+```
+
 build
 ```sh
 cabal v2-build --ghc-options=-Werror
@@ -54,5 +59,5 @@ nix-env --install --file release.nix --attr nix-shell-bit
 Todos:
 - [ ] use conduit-extra
 - [ ] pin nixpkgs and ghc
-- [ ] update test/suite integration tests
+- [x] update test/suite integration tests
 - [x] nix derivation

--- a/test/integration
+++ b/test/integration
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p bats coreutils findutils gawk git gnugrep gnused ncurses perl socat utillinux
+#! nix-shell -i bash -p bats coreutils findutils gawk git gnugrep ncurses perl socat utillinux
 
 set -eu
 

--- a/test/integration
+++ b/test/integration
@@ -3,51 +3,58 @@
 
 set -eu
 
-export ORIG_PWD SANDBOX XDG_CONFIG_HOME EXECUTABLE
-ORIG_PWD="$PWD"
+export ORIG_PWD="$PWD"
 TOPLEVEL=$(git -C "${BASH_SOURCE[0]%/*}" rev-parse --show-toplevel)
-SANDBOX=$(mktemp -dt "nix-shell-bit-sandbox.XXXXXX")
-XDG_CONFIG_HOME="$SANDBOX/XDG_CONFIG_HOME.seed"
+
+SANDBOX=$(mktemp -dt "integration-test-sandbox.XXXXXX")
+export SAND="$SANDBOX/sand"
+export SEED="$SANDBOX/seed"
+export XDG_CONFIG_HOME="$SAND/XDG_CONFIG_HOME"
+export LOCAL_PROJECT="$SAND/PROJECT-local"
+export REMOTE_SHELLS="$SAND/NIX_SHELLS"
+
+nix-shell --run 'cabal v2-build'
+export EXECUTABLE=$(find $TOPLEVEL           \
+                         -type f -executable \
+                         -name nix-shell-bit \
+                         -printf "%T@ %p\n"  \
+                    | sort -n | tail -n 1    \
+                    | awk '{print $NF}')
 
 trap "cd '$ORIG_PWD'; rm -rf '$SANDBOX'" EXIT INT QUIT TERM
 
-mkdir "$SANDBOX/"{remotes,locals}
+mkdir "$SAND"
 
-# Prepare executable
-nix-shell --run 'cabal v2-build'
-EXECUTABLE=$(find $TOPLEVEL \
-                  -type f \
-                  -executable \
-                  -name nix-shell-bit \
-                  -printf "%T@ %p\n" \
-             | sort -n | tail -n 1 | awk '{print $NF}')
-
-# Configure sandbox
-mkdir "$XDG_CONFIG_HOME"
-mkdir "$XDG_CONFIG_HOME/git"
+# Configure sandbox git
+mkdir "$XDG_CONFIG_HOME" \
+      "$XDG_CONFIG_HOME/git"
 touch "$XDG_CONFIG_HOME/git/config"
 git config --global user.email "nobody@example.com"
 git config --global user.name "nobody"
+
+# Configure sandbox nix-shell-bit
 mkdir "$XDG_CONFIG_HOME/nix-shell-bit"
 cat > "$XDG_CONFIG_HOME/nix-shell-bit/config.dhall" <<EOF
 { nixShellBitUrl =
-    [ "$SANDBOX/NIX_SHELL_BIT_URL" ] : Optional Text
+    [ "$REMOTE_SHELLS" ] : Optional Text
 , nixShellBitBranch =
     [] : Optional Text
 }
 EOF
 
 # Prepare project remote
-git init --quiet --template='' "$SANDBOX/remotes/PROJECT"
-echo '0.1.0' > "$SANDBOX/remotes/PROJECT/VERSION"
-git -C "$SANDBOX/remotes/PROJECT" add VERSION
-git -C "$SANDBOX/remotes/PROJECT" commit --quiet -m '0.1.0'
+REMOTE_PROJECT="$SAND/PROJECT"
+git init --quiet --template='' "$REMOTE_PROJECT"
+echo '0.1.0' > "$REMOTE_PROJECT/VERSION"
+git -C "$REMOTE_PROJECT" add VERSION
+git -C "$REMOTE_PROJECT" commit --quiet -m '0.1.0'
 
 # Prepare seeds
-git clone --quiet --template='' "$SANDBOX/remotes/PROJECT" "$SANDBOX/locals/PROJECT.seed"
+git clone --quiet --template='' "$REMOTE_PROJECT" "$LOCAL_PROJECT"
 
-git init --quiet --template='' "$SANDBOX/NIX_SHELL_BIT_URL.seed"
-cat > "$SANDBOX/NIX_SHELL_BIT_URL.seed/default.nix" <<'EOF'
+# Setup remote derivation
+git init --quiet --template='' "$REMOTE_SHELLS"
+cat > "$REMOTE_SHELLS/default.nix" <<'EOF'
 {
   PROJECT = (import <nixpkgs> {}).mkShell {
     name = "PROJECT";
@@ -59,11 +66,13 @@ cat > "$SANDBOX/NIX_SHELL_BIT_URL.seed/default.nix" <<'EOF'
   };
 }
 EOF
-git -C "$SANDBOX/NIX_SHELL_BIT_URL.seed" add default.nix
-git -C "$SANDBOX/NIX_SHELL_BIT_URL.seed" commit --quiet -m 'PROJECT 0.1.0'
-git -C "$SANDBOX/NIX_SHELL_BIT_URL.seed" tag PROJECT-0.1.0
+git -C "$REMOTE_SHELLS" add default.nix
+git -C "$REMOTE_SHELLS" commit --quiet -m 'PROJECT 0.1.0'
+git -C "$REMOTE_SHELLS" tag PROJECT-0.1.0
 
-XDG_CONFIG_HOME="$SANDBOX/XDG_CONFIG_HOME" \
-    bats ${CI:+--tap} --recursive "$TOPLEVEL/test"
+# Save state to seed
+cp -r "$SAND" "$SEED"
+
+bats ${CI:+--tap} --recursive "$TOPLEVEL/test"
 
 # vim: filetype=sh

--- a/test/integration
+++ b/test/integration
@@ -3,7 +3,7 @@
 
 set -eu
 
-export ORIG_PWD TOPLEVEL SANDBOX XDG_CONFIG_HOME
+export ORIG_PWD SANDBOX XDG_CONFIG_HOME EXECUTABLE
 ORIG_PWD="$PWD"
 TOPLEVEL=$(git -C "${BASH_SOURCE[0]%/*}" rev-parse --show-toplevel)
 SANDBOX=$(mktemp -dt "nix-shell-bit-sandbox.XXXXXX")
@@ -13,6 +13,15 @@ trap "cd '$ORIG_PWD'; rm -rf '$SANDBOX'" EXIT INT QUIT TERM
 
 mkdir "$SANDBOX/"{remotes,locals}
 
+# Prepare executable
+nix-shell --run 'cabal v2-build'
+EXECUTABLE=$(find $TOPLEVEL \
+                  -type f \
+                  -executable \
+                  -name nix-shell-bit \
+                  -printf "%T@ %p\n" \
+             | sort -n | tail -n 1 | awk '{print $NF}')
+
 # Configure sandbox
 mkdir "$XDG_CONFIG_HOME"
 mkdir "$XDG_CONFIG_HOME/git"
@@ -20,8 +29,13 @@ touch "$XDG_CONFIG_HOME/git/config"
 git config --global user.email "nobody@example.com"
 git config --global user.name "nobody"
 mkdir "$XDG_CONFIG_HOME/nix-shell-bit"
-printf ': "${NIX_SHELL_BIT_URL=%s}"\n' "$SANDBOX/NIX_SHELL_BIT_URL" \
-    >> "$XDG_CONFIG_HOME/nix-shell-bit/env"
+cat > "$XDG_CONFIG_HOME/nix-shell-bit/config.dhall" <<EOF
+{ nixShellBitUrl =
+    [ "$SANDBOX/NIX_SHELL_BIT_URL" ] : Optional Text
+, nixShellBitBranch =
+    [] : Optional Text
+}
+EOF
 
 # Prepare project remote
 git init --quiet --template='' "$SANDBOX/remotes/PROJECT"

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -1,17 +1,13 @@
 #! /usr/bin/env bats
 
 setup() {
-    cp -r "$SANDBOX/NIX_SHELL_BIT_URL"{.seed,}
-    cp -r "$SANDBOX/XDG_CONFIG_HOME"{.seed,}
-    cp -r "$SANDBOX/locals/PROJECT"{.seed,}
-    cd "$SANDBOX/locals/PROJECT"
+    cp -r "$SEED" "$SAND"
+    cd "$LOCAL_PROJECT"
 }
 
 teardown() {
     cd "$ORIG_PWD"
-    rm -rf "$SANDBOX/locals/PROJECT"
-    rm -rf "$SANDBOX/XDG_CONFIG_HOME"
-    rm -rf "$SANDBOX/NIX_SHELL_BIT_URL"
+    rm -rf "$SAND"
 }
 
 pseudo_tty() {
@@ -36,10 +32,10 @@ colorstrip() {
 }
 
 @test 'it prompts for NIX_SHELL_BIT_URL if it cannot be detected' {
-    local url="$SANDBOX/NIX_SHELL_BIT_URL"
+    local url="$REMOTE_SHELLS"
     local out
 
-    rm "$SANDBOX/XDG_CONFIG_HOME/nix-shell-bit/config.dhall"
+    rm "$XDG_CONFIG_HOME/nix-shell-bit/config.dhall"
 
     out=$(
         pseudo_tty "$EXECUTABLE" \
@@ -47,8 +43,8 @@ colorstrip() {
             2>&1 | colorstrip
     )
 
-    grep -F 'NIX_SHELL_BIT_URL not found'       <<< "$out"
-    grep -F 'Please enter NIX_SHELL_BIT_URL'    <<< "$out"
+    grep -F 'NIX_SHELL_BIT_URL not found'    <<< "$out"
+    grep -F 'Please enter NIX_SHELL_BIT_URL' <<< "$out"
 }
 
 @test 'it enters a development environment' {
@@ -62,8 +58,8 @@ colorstrip() {
 }
 
 @test 'it can use a specific NIX_SHELL_BIT_BRANCH' {
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" checkout -b fnord
-    cat > "$SANDBOX/NIX_SHELL_BIT_URL/default.nix" <<'EOF'
+    git -C "$REMOTE_SHELLS" checkout -b fnord
+    cat > "$REMOTE_SHELLS/default.nix" <<'EOF'
 {
   PROJECT = (import <nixpkgs> {}).mkShell {
     shellHook = ''
@@ -73,7 +69,7 @@ colorstrip() {
   };
 }
 EOF
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" commit --all --quiet -m 'fnord'
+    git -C "$REMOTE_SHELLS" commit --all --quiet -m 'fnord'
 
     NIX_SHELL_BIT_BRANCH=fnord \
         "$EXECUTABLE" \

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -31,184 +31,33 @@ colorstrip() {
 }
 
 @test 'it shows Usage if --help option is used' {
-    "$TOPLEVEL/bin/nix-shell-bit" --help 2>&1 \
+    "$EXECUTABLE" --help 2>&1 \
         | grep -F 'Usage'
-}
-
-@test 'it returns zero exit code if --help option is used' {
-    "$TOPLEVEL/bin/nix-shell-bit" --help
-}
-
-@test 'it shows error if PROJECT cannot be detected' {
-    rm -rf "$SANDBOX/locals/PROJECT/.git"
-    "$TOPLEVEL/bin/nix-shell-bit" 2>&1 \
-        | tail -3 \
-        | grep -iF 'detect PROJECT'
-}
-
-@test 'it returns non-zero exit code if PROJECT cannot be detected' {
-    rm -rf "$SANDBOX/locals/PROJECT/.git"
-    ! "$TOPLEVEL/bin/nix-shell-bit"
-}
-
-@test 'it shows error if VERSION cannot be detected' {
-    rm "$SANDBOX/locals/PROJECT/VERSION"
-    "$TOPLEVEL/bin/nix-shell-bit" 2>&1 \
-        | tail -3 \
-        | grep -iF 'detect VERSION'
-}
-
-@test 'it returns non-zero exit code if VERSION cannot be detected' {
-    rm "$SANDBOX/locals/PROJECT/VERSION"
-    ! "$TOPLEVEL/bin/nix-shell-bit"
 }
 
 @test 'it prompts for NIX_SHELL_BIT_URL if it cannot be detected' {
     local url="$SANDBOX/NIX_SHELL_BIT_URL"
     local out
 
+    rm "$SANDBOX/XDG_CONFIG_HOME/nix-shell-bit/config.dhall"
+
     out=$(
-        NIX_SHELL_BIT_URL='' \
-            pseudo_tty "$TOPLEVEL/bin/nix-shell-bit" --list \
+        pseudo_tty "$EXECUTABLE" \
             < <(echo "$url" && echo '') \
             2>&1 | colorstrip
     )
 
-    grep -F 'NIX_SHELL_BIT_URL not found'    <<< "$out"
-    grep -F 'Please enter NIX_SHELL_BIT_URL' <<< "$out"
+    grep -F 'NIX_SHELL_BIT_URL not found'       <<< "$out"
+    grep -F 'Please enter NIX_SHELL_BIT_URL'    <<< "$out"
 }
 
-@test 'it saves config by default' {
-    local config="$XDG_CONFIG_HOME/nix-shell-bit/env"
-    local url="$SANDBOX/NIX_SHELL_BIT_URL"
-
-    rm "$config" && rmdir "${config%/*}"
-
-    "$TOPLEVEL/bin/nix-shell-bit" --list \
-        < <(echo "$url" && echo '')
-
-    grep -F ": \"\${NIX_SHELL_BIT_URL:=$url}\"" "$config"
-}
-
-@test 'it lets user decline saving config' {
-    local url="$SANDBOX/NIX_SHELL_BIT_URL"
-    local config="$XDG_CONFIG_HOME/nix-shell-bit/env"
-
-    rm "$config" && rmdir "${config%/*}"
-
-    "$TOPLEVEL/bin/nix-shell-bit" --list \
-        < <(echo "$url" && echo 'no')
-
-    ! test -f "$config"
-}
-
-@test 'it reprompts about saving config if answer is invalid' {
-    local url="$SANDBOX/NIX_SHELL_BIT_URL"
-    local reprompt="Please answer y or n "
-    local config="$XDG_CONFIG_HOME/nix-shell-bit/env"
-
-    rm "$config" && rmdir "${config%/*}"
-
-    out=$(
-        pseudo_tty "$TOPLEVEL/bin/nix-shell-bit" --list \
-            < <(echo "$url" && echo 'fnord' && echo 'yes') \
-            2>&1
-    )
-
-    grep -z "Save config to $XDG_CONFIG_HOME/.*Please answer y or n" <<< "$out"
-    test -f "$config"
-}
-
-@test 'it returns non-zero exit code if NIX_SHELL_BIT_URL cannot be read' {
-    ! NIX_SHELL_BIT_URL=/dev/null \
-        "$TOPLEVEL/bin/nix-shell-bit"
-}
-
-@test 'it returns non-zero exit code if NIX_SHELL_BIT_BRANCH cannot be read' {
-    ! NIX_SHELL_BIT_BRANCH=fnord \
-        "$TOPLEVEL/bin/nix-shell-bit"
-}
-
-@test 'it shows error if no versions are available for PROJECT' {
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag --delete PROJECT-0.1.0
-    "$TOPLEVEL/bin/nix-shell-bit" 2>&1 \
-        | tail -1 \
-        | grep -iF 'no versions'
-}
-
-@test 'it returns non-zero exit code if no versions are available for PROJECT' {
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag --delete PROJECT-0.1.0
-    ! "$TOPLEVEL/bin/nix-shell-bit"
-}
-
-@test 'it shows error if VERSION is unavailable' {
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag --delete PROJECT-0.1.0 >/dev/null
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag PROJECT-0.0.5
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag PROJECT-0.0.6
-
-    "$TOPLEVEL/bin/nix-shell-bit" 2>&1 \
-        | grep -iF '0.1.0 not found'
-}
-
-@test 'it lists available versions if VERSION is unavailable' {
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag --delete PROJECT-0.1.0 >/dev/null
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag PROJECT-0.0.5
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag PROJECT-0.0.6
-
-    local out
-    out=$("$TOPLEVEL/bin/nix-shell-bit" 2>&1 || true)
-
-    grep '\<0\.0\.5\>' <<< "$out"
-    grep '\<0\.0\.6\>' <<< "$out"
-}
-
-@test 'it returns non-zero exit code if VERSION is unavailable' {
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag --delete PROJECT-0.1.0 >/dev/null
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag PROJECT-0.0.5
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag PROJECT-0.0.6
-
-    ! "$TOPLEVEL/bin/nix-shell-bit"
-}
-
-@test 'it lists available versions if --list is used' {
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag PROJECT-0.0.9
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag PROJECT-0.1.1
-
-    local out
-    out=$("$TOPLEVEL/bin/nix-shell-bit" --list 2>&1 | colorstrip)
-
-    grep '\<0\.0\.9\>' <<< "$out"
-    grep '\<0\.1\.0\>' <<< "$out"
-    grep '\<0\.1\.1\>' <<< "$out"
-}
-
-@test 'it returns zero exit code after listing available versions' {
-    "$TOPLEVEL/bin/nix-shell-bit" --list
-}
-
-@test 'it does not warn about unavailable VERSION if --list is used' {
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag --delete PROJECT-0.1.0 >/dev/null
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag PROJECT-0.0.9
-    git -C "$SANDBOX/NIX_SHELL_BIT_URL" tag PROJECT-0.1.1
-
-    local out
-    out=$("$TOPLEVEL/bin/nix-shell-bit" --list 2>&1)
-
-    ! grep -iF '0.1.0 not found' <<< "$out"
-}
-
-@test 'it is not an error when VERSION cannot be detected if --list is used' {
-    rm "$SANDBOX/locals/PROJECT/VERSION"
-    "$TOPLEVEL/bin/nix-shell-bit" --list
-}
-
-@test 'it enters the development environment' {
-    "$TOPLEVEL/bin/nix-shell-bit" \
+@test 'it enters a development environment' {
+    "$EXECUTABLE" \
         | grep -F "Entered PROJECT 0.1.0 environment"
 }
 
 @test 'it can pass additional options to nix-shell' {
-    AUTO= "$TOPLEVEL/bin/nix-shell-bit" --run 'echo "version: $version"' \
+    AUTO= "$EXECUTABLE" -- --run 'echo "version: $version"' \
         | grep -F "version: 0.1.0"
 }
 
@@ -227,6 +76,6 @@ EOF
     git -C "$SANDBOX/NIX_SHELL_BIT_URL" commit --all --quiet -m 'fnord'
 
     NIX_SHELL_BIT_BRANCH=fnord \
-        "$TOPLEVEL/bin/nix-shell-bit" \
+        "$EXECUTABLE" \
         | grep -F 'I am fnord'
 }


### PR DESCRIPTION
Most of the tests that accompanied the Bash prototype have been made redundant by the Hspec test suite, but it would be useful to keep a few around as integration tests.

The Hspec tests have to stop short of exec'ing a nix-shell, since that replaces the Haskell process itself. A few bats integration tests can fill this gap in coverage, providing some end-to-end tests.