### PR TITLE
Darwin needs a newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,5 @@ make update-nixpkgs REV=bc94dcf500286495e3c478a9f9322debc94c4304
 
 ## Todos
 
+- [ ] replace column with a Haskell implementation
 - [ ] use conduit-extra

--- a/src/NixShellBit/PPrint.hs
+++ b/src/NixShellBit/PPrint.hs
@@ -82,7 +82,7 @@ listItems' hdl items focusItem =
       setStdin (byteStringInput bs) (proc "column" [])
 
     bs :: C.ByteString
-    bs = C.pack $ displayS (renderPretty 1.0 80 doc) ""
+    bs = C.pack $ displayS (renderPretty 1.0 80 doc) "\n"
 
     doc :: Doc
     doc = sep (map toDoc items)


### PR DESCRIPTION
Add a terminating newline to the input we pass to the `column` util. This prevents an error when run on mac:
```
column: line too long
```