### PR TITLE
Implement column in Haskell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ nix-build: default.nix
 	@echo "Running nix-build"
 	@nix-build ./nix --attr full
 
+.PHONY: nix-build-minimal
+nix-build-minimal: default.nix
+	@echo "Running nix-build"
+	@nix-build ./nix --attr minimal
+
 .PHONY: completions
 completions: default.nix
 	@echo "Generating completions"
@@ -54,13 +59,16 @@ completions: default.nix
 
 .PHONY: install
 install: default.nix
-	@echo "Installing to user profile with nix-env"
 	@nix-env --install --file ./nix --attr full
+
+.PHONY: install-minimal
+install-minimal: default.nix
+	@nix-env --install --file ./nix --attr minimal
 
 .PHONY: uninstall
 uninstall: default.nix
-	@echo "Uninstalling from user profile with nix-env"
 	@nix-env --uninstall $(PROJECT_NAME)
+	@nix-env --uninstall $(PROJECT_NAME)-minimal
 
 default.nix: $(PROJECT_NAME).cabal
 	@echo "Generating default.nix"

--- a/README.md
+++ b/README.md
@@ -54,5 +54,4 @@ make update-nixpkgs REV=bc94dcf500286495e3c478a9f9322debc94c4304
 
 ## Todos
 
-- [ ] replace column with a Haskell implementation
 - [ ] use conduit-extra

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, ansi-wl-pprint, attoparsec, base, bytestring
 , Cabal, dhall, directory, filemanip, filepath, haskeline, hlibgit2
 , hspec, main-tester, optparse-applicative, prettyprinter
-, regex-tdfa, safe, stdenv, temporary, text, transformers
-, typed-process, unix, unliftio
+, regex-tdfa, safe, stdenv, temporary, terminal-size, text
+, transformers, typed-process, unix, unliftio
 }:
 mkDerivation {
   pname = "nix-shell-bit";
@@ -13,8 +13,8 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson ansi-wl-pprint attoparsec base bytestring Cabal dhall
     directory filemanip filepath haskeline hlibgit2
-    optparse-applicative prettyprinter safe temporary text transformers
-    typed-process unix unliftio
+    optparse-applicative prettyprinter safe temporary terminal-size
+    text transformers typed-process unix unliftio
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [

--- a/nix-shell-bit.cabal
+++ b/nix-shell-bit.cabal
@@ -30,28 +30,28 @@ library
       NixShellBit.Line
       Paths_nix_shell_bit
   build-depends:
-      aeson                >= 1.4  && < 1.5
-    , ansi-wl-pprint       >= 0.6  && < 0.7
-    , attoparsec           >= 0.13 && < 0.14
-    , base                 >= 4.12 && < 5
-    , bytestring           >= 0.10 && < 0.11
-    , Cabal                >= 2.4  && < 2.5
-    , dhall                >= 1.19 && < 1.20
-    , directory            >= 1.3  && < 1.4
-    , filemanip            >= 0.3  && < 0.4
-    , filepath             >= 1.4  && < 1.5
-    , haskeline            >= 0.7  && < 0.8
-    , hlibgit2             >= 0.18 && < 0.19
-    , optparse-applicative >= 0.14 && < 0.15
-    , prettyprinter        >= 1.2  && < 1.3
-    , safe                 >= 0.3  && < 0.4
-    , temporary            >= 1.3  && < 1.4
+      aeson                >= 1.4      && < 1.5
+    , ansi-wl-pprint       >= 0.6      && < 0.7
+    , attoparsec           >= 0.13     && < 0.14
+    , base                 >= 4.12     && < 5
+    , bytestring           >= 0.10     && < 0.11
+    , Cabal                >= 2.4      && < 2.5
+    , dhall                >= 1.19     && < 1.20
+    , directory            >= 1.3      && < 1.4
+    , filemanip            >= 0.3      && < 0.4
+    , filepath             >= 1.4      && < 1.5
+    , haskeline            >= 0.7      && < 0.8
+    , hlibgit2             >= 0.18     && < 0.19
+    , optparse-applicative >= 0.14     && < 0.15
+    , prettyprinter        >= 1.2      && < 1.3
+    , safe                 >= 0.3      && < 0.4
+    , temporary            >= 1.3      && < 1.4
     , terminal-size        >= 0.3.2.1  && < 0.4
-    , text                 >= 1.2  && < 1.3
-    , transformers         >= 0.5  && < 0.6
-    , typed-process        >= 0.2  && < 0.3
-    , unix                 >= 2.7  && < 2.8
-    , unliftio             >= 0.2  && < 0.3
+    , text                 >= 1.2      && < 1.3
+    , transformers         >= 0.5      && < 0.6
+    , typed-process        >= 0.2      && < 0.3
+    , unix                 >= 2.7      && < 2.8
+    , unliftio             >= 0.2      && < 0.3
   hs-source-dirs:
       src
   ghc-options: -Wall -O2

--- a/nix-shell-bit.cabal
+++ b/nix-shell-bit.cabal
@@ -25,6 +25,7 @@ library
       NixShellBit.PPrint
       NixShellBit.Project
       NixShellBit.Version
+      NixShellBit.Column
   other-modules:
       NixShellBit.Line
       Paths_nix_shell_bit
@@ -45,6 +46,7 @@ library
     , prettyprinter        >= 1.2  && < 1.3
     , safe                 >= 0.3  && < 0.4
     , temporary            >= 1.3  && < 1.4
+    , terminal-size        >= 0.3.2.1  && < 0.4
     , text                 >= 1.2  && < 1.3
     , transformers         >= 0.5  && < 0.6
     , typed-process        >= 0.2  && < 0.3
@@ -69,6 +71,7 @@ test-suite nix-shell-bit-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      NixShellBit.ColumnSpec
       NixShellBit.ConfigSpec
       NixShellBit.GitSpec
       NixShellBit.MainSpec

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,7 +19,6 @@ let
   runtimeDeps = [
     git
     nix
-    utillinux
   ];
 
   devUtils = [

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -34,6 +34,10 @@ in
       paths = [ pkg ] ++ runtimeDeps;
     };
 
+    minimal = pkg.overrideAttrs (old: rec {
+      name = "nix-shell-bit-minimal";
+    });
+
     dev = drv.env.overrideAttrs (old: rec {
       buildInputs = old.buildInputs ++ runtimeDeps ++ devUtils;
     });

--- a/src/NixShellBit/Column.hs
+++ b/src/NixShellBit/Column.hs
@@ -1,0 +1,98 @@
+module NixShellBit.Column
+  ( grid
+  , terminalWidth
+  ) where
+
+import Control.Applicative       ((<|>))
+import Control.Monad.Trans.Maybe (MaybeT(MaybeT), runMaybeT)
+import Data.Foldable             (foldl')
+import Data.List                 (unfoldr)
+import Data.Maybe                (fromMaybe)
+import System.Environment        (lookupEnv)
+import Text.Read                 (readMaybe)
+
+import qualified System.Console.Terminal.Size as Terminal
+
+
+type Column = (String, Padding)
+
+type Padding = String
+
+
+tabWidth :: Int
+tabWidth = 8
+
+
+grid :: [String] -> Int -> [[Column]]
+grid [] _     = []
+grid xs width =
+    if maxLength >= width
+      then map (\x -> [(x, "")]) items
+      else map (unfoldr column) [0 .. numrows - 1]
+  where
+    maxLength :: Int
+    maxLength =
+      foldl' (\z -> max z . length) 0 items
+
+    column :: Int -> Maybe (Column, Int)
+    column i =
+        if i >= numItems
+          then Nothing
+          else Just ((item, padding), i + numrows)
+      where
+        item :: String
+        item = items !! i
+
+        padding :: Padding
+        padding = replicate padCount '\t'
+
+        padCount :: Int
+        padCount =
+          if i + numrows >= numItems
+            then 0
+            else qPad + signum rPad
+
+        qPad, rPad :: Int
+        (qPad, rPad) = quotRem (columnWidth - length item) tabWidth
+
+    numrows :: Int
+    numrows = qRows + signum rRows
+
+    qRows, rRows :: Int
+    (qRows, rRows) = quotRem numItems numcols
+
+    numcols :: Int
+    numcols = max 1 (width `quot` columnWidth)
+
+    columnWidth :: Int
+    columnWidth = addTab maxLength
+
+    addTab :: Int -> Int
+    addTab pos =
+      pos + tabWidth - (pos `rem` tabWidth)
+
+    numItems :: Int
+    numItems = length items
+
+    items :: [String]
+    items = filter (not . null) xs
+
+
+terminalWidth :: IO Int
+terminalWidth =
+    fromMaybe defaultWidth <$> runMaybeT (fromTTY <|> fromEnv)
+  where
+    fromTTY :: MaybeT IO Int
+    fromTTY = s >>= w
+      where
+        s = MaybeT Terminal.size
+        w = MaybeT . pure . Just . Terminal.width
+
+    fromEnv :: MaybeT IO Int
+    fromEnv = c >>= i
+      where
+        c = MaybeT (lookupEnv "COLUMNS")
+        i = MaybeT . pure . readMaybe
+
+    defaultWidth :: Int
+    defaultWidth = 80

--- a/src/NixShellBit/Config.hs
+++ b/src/NixShellBit/Config.hs
@@ -22,7 +22,7 @@ import System.Directory          (XdgDirectory(XdgConfig),
 import System.Environment        (lookupEnv)
 import System.FilePath           (takeDirectory, takeFileName, (</>), (<.>))
 
-import qualified Data.ByteString.Char8 as C
+import qualified Data.ByteString.Char8 as BS8
 import qualified Data.Text as T
 import qualified Dhall
 
@@ -125,7 +125,7 @@ save config =
     write :: FilePath -> IO ()
     write path =
       createDirectoryIfMissing True (takeDirectory path) >>
-      C.writeFile path (serialize attrs)
+      BS8.writeFile path (serialize attrs)
 
     attrs :: Attrs
     attrs = Attrs
@@ -134,9 +134,9 @@ save config =
       }
 
 
-serialize :: Attrs -> C.ByteString
+serialize :: Attrs -> BS8.ByteString
 serialize =
-    C.pack . show . unAnnotate . prettyExpr . embed input
+    BS8.pack . show . unAnnotate . prettyExpr . embed input
   where
     input :: InputType Attrs
     input =

--- a/src/NixShellBit/Git.hs
+++ b/src/NixShellBit/Git.hs
@@ -34,8 +34,8 @@ import System.FilePath      (searchPathSeparator)
 import System.Process.Typed (proc, readProcessStdout_, readProcess_)
 import UnliftIO.Exception   (Exception, Typeable, throwIO)
 
-import qualified Data.ByteString.Char8 as C
-import qualified Data.ByteString.Lazy.Char8 as L
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy.Char8 as BSL8
 import qualified Data.Text as T
 
 
@@ -164,7 +164,7 @@ gitTaggedVersions
 gitTaggedVersions url name =
   do
     out <- readProcessStdout_ (proc "git" ls_remote)
-    pure $ mapMaybe v (L.lines out)
+    pure $ mapMaybe v (BSL8.lines out)
   where
     ls_remote :: [String]
     ls_remote =
@@ -175,15 +175,15 @@ gitTaggedVersions url name =
       , name ++ "-*"
       ]
 
-    v :: L.ByteString -> Maybe String
-    v = fmap C.unpack
-      . C.stripPrefix prefix
+    v :: BSL8.ByteString -> Maybe String
+    v = fmap BS8.unpack
+      . BS8.stripPrefix prefix
       . snd
-      . C.breakSubstring prefix
-      . L.toStrict
+      . BS8.breakSubstring prefix
+      . BSL8.toStrict
 
-    prefix :: C.ByteString
-    prefix = "refs/tags/" <> C.pack name <> "-"
+    prefix :: BS8.ByteString
+    prefix = "refs/tags/" <> BS8.pack name <> "-"
 
 
 {-| hlibgit2 has a c'git_clone binding but using it would mean

--- a/src/NixShellBit/PPrint.hs
+++ b/src/NixShellBit/PPrint.hs
@@ -22,7 +22,7 @@ import Text.PrettyPrint.ANSI.Leijen (Doc, bold, brackets, char, colon, debold,
                              displayS, dquotes, hcat, hPutDoc, hsep, line, red,
                              renderPretty, sep, space, text, vcat, yellow, (<+>))
 
-import qualified Data.ByteString.Lazy.Char8 as C
+import qualified Data.ByteString.Lazy.Char8 as BSL8
 
 
 askUrl :: IO String
@@ -75,14 +75,14 @@ listItems = listItems' stdout
 
 listItems' :: Handle -> [String] -> Maybe String -> IO ()
 listItems' hdl items focusItem =
-    columns >>= C.hPut hdl >> hFlush hdl
+    columns >>= BSL8.hPut hdl >> hFlush hdl
   where
-    columns :: IO C.ByteString
+    columns :: IO BSL8.ByteString
     columns = readProcessStdout_ $
       setStdin (byteStringInput bs) (proc "column" [])
 
-    bs :: C.ByteString
-    bs = C.pack $ displayS (renderPretty 1.0 80 doc) "\n"
+    bs :: BSL8.ByteString
+    bs = BSL8.pack $ displayS (renderPretty 1.0 80 doc) "\n"
 
     doc :: Doc
     doc = sep (map toDoc items)

--- a/src/NixShellBit/PPrint.hs
+++ b/src/NixShellBit/PPrint.hs
@@ -15,14 +15,14 @@ module NixShellBit.PPrint
   ) where
 
 import Data.Char            (toLower)
+import NixShellBit.Column   (grid, terminalWidth)
 import NixShellBit.Line     (readline)
 import System.IO            (Handle, hFlush, stderr, stdout)
-import System.Process.Typed (byteStringInput, proc, readProcessStdout_, setStdin)
 import Text.PrettyPrint.ANSI.Leijen (Doc, bold, brackets, char, colon, debold,
                              displayS, dquotes, hcat, hPutDoc, hsep, line, red,
-                             renderPretty, sep, space, text, vcat, yellow, (<+>))
+                             renderPretty, space, text, vcat, yellow, (<+>))
 
-import qualified Data.ByteString.Lazy.Char8 as BSL8
+import qualified Data.ByteString.Char8 as BS8
 
 
 askUrl :: IO String
@@ -75,21 +75,21 @@ listItems = listItems' stdout
 
 listItems' :: Handle -> [String] -> Maybe String -> IO ()
 listItems' hdl items focusItem =
-    columns >>= BSL8.hPut hdl >> hFlush hdl
+    renderGrid <$> terminalWidth
+      >>= BS8.hPut hdl
+       >> hFlush hdl
   where
-    columns :: IO BSL8.ByteString
-    columns = readProcessStdout_ $
-      setStdin (byteStringInput bs) (proc "column" [])
+    renderGrid :: Int -> BS8.ByteString
+    renderGrid width =
+        BS8.pack $ displayS (renderPretty 1.0 width rows) "\n"
+      where
+        rows = vcat (map (hcat . map column) (grid items width))
 
-    bs :: BSL8.ByteString
-    bs = BSL8.pack $ displayS (renderPretty 1.0 80 doc) "\n"
-
-    doc :: Doc
-    doc = sep (map toDoc items)
-
-    toDoc :: String -> Doc
-    toDoc x | Just x == focusItem = bold (text x)
-            | otherwise = debold (text x)
+    column :: (String, String) -> Doc
+    column (x, p) =
+        style (text x) <> text p
+      where
+        style = if Just x == focusItem then bold else debold
 
 
 noProject :: Doc

--- a/src/NixShellBit/Version.hs
+++ b/src/NixShellBit/Version.hs
@@ -23,7 +23,7 @@ import System.FilePath.Find      (FileType(RegularFile), FilterPredicate, depth,
                                   extension, fileName, fileType, find, (==?),
                                   (&&?))
 
-import qualified Data.ByteString.Char8 as C
+import qualified Data.ByteString.Char8 as BS8
 
 
 newtype Version = Version
@@ -99,5 +99,5 @@ detectVersion directory =
     genericPkgVersion :: FilePath -> MaybeT IO Version
     genericPkgVersion path =
       do
-        line <- MaybeT (listToMaybe . C.lines <$> C.readFile path)
-        pure $ Version (C.unpack line)
+        line <- MaybeT (listToMaybe . BS8.lines <$> BS8.readFile path)
+        pure $ Version (BS8.unpack line)

--- a/test/NixShellBit/ColumnSpec.hs
+++ b/test/NixShellBit/ColumnSpec.hs
@@ -1,0 +1,60 @@
+module NixShellBit.ColumnSpec (spec) where
+
+import NixShellBit.Column (grid)
+import Test.Hspec         (Spec, describe, it, shouldBe)
+
+
+spec :: Spec
+spec =
+  describe "grid" $ do
+    it "is empty when given an empty list" $
+      grid [] 16 `shouldBe` []
+
+    it "is empty when all elements are empty" $
+      grid [""] 16 `shouldBe` []
+
+    it "is 1 x 1 when given a singleton list" $
+      grid ["a"] 16 `shouldBe` [ [("a","")] ]
+
+    it "has one row when all items can fit on one line" $
+      grid ["a", "b"] 16 `shouldBe`
+        [ [("a","\t"), ("b","")] ]
+
+    it "has one column if any item is >= width" $
+      grid ["a", "b234567812345678", "c"] 16 `shouldBe`
+        [ [("a","")]
+        , [("b234567812345678","")]
+        , [("c","")]
+        ]
+
+    it "excludes empty items from single-column result" $
+      grid ["a", "", "b234567812345678", "c"] 16 `shouldBe`
+        [ [("a","")]
+        , [("b234567812345678","")]
+        , [("c","")]
+        ]
+
+    it "fills columns before rows" $
+      grid ["a", "b", "c", "d", "e"] 32 `shouldBe`
+        [ [("a","\t"), ("c","\t"), ("e","")]
+        , [("b","\t"), ("d","")]
+        ]
+
+    it "excludes empty items from multi-column result" $
+      grid ["a", "", "b", "c", "d"] 16 `shouldBe`
+        [ [("a","\t"), ("c","")]
+        , [("b","\t"), ("d","")]
+        ]
+
+    it "has a partial row for overflow items" $
+      grid ["a", "b", "c", "d", "e"] 16 `shouldBe`
+        [ [("a","\t"), ("d","")]
+        , [("b","\t"), ("e","")]
+        , [("c","")]
+        ]
+
+    it "applies padding to maintain a consistent column width" $
+      grid ["a", "b", "c", "d2345678", "e", "f"] 48 `shouldBe`
+        [ [("a","\t\t"), ("c",     "\t\t"), ("e","")]
+        , [("b","\t\t"), ("d2345678","\t"), ("f","")]
+        ]

--- a/test/NixShellBit/GitSpec.hs
+++ b/test/NixShellBit/GitSpec.hs
@@ -13,7 +13,7 @@ import System.Process.Typed (proc, readProcess_, readProcessStdout_)
 import Test.Hspec           (Spec, before_, context, describe, it, shouldBe,
                              shouldReturn, shouldThrow)
 
-import qualified Data.ByteString.Lazy.Char8 as C
+import qualified Data.ByteString.Lazy.Char8 as BSL8
 import qualified Data.Text as T
 
 
@@ -124,7 +124,7 @@ spec sand = do
         o <- readProcessStdout_
            $ proc "git" ["-C", dest, "remote", "get-url", "origin"]
 
-        lines (C.unpack o) `shouldBe` lines url
+        lines (BSL8.unpack o) `shouldBe` lines url
 
       it "checks out the requested branch" $ do
         traverse_ (readProcess_ . proc "git")
@@ -138,7 +138,7 @@ spec sand = do
         o <- readProcessStdout_ $ proc "git"
              ["-C", dest, "rev-parse", "--abbrev-ref", "HEAD"]
 
-        lines (C.unpack o) `shouldBe` lines "foo"
+        lines (BSL8.unpack o) `shouldBe` lines "foo"
 
 
     describe "gitRemoteGetUrl" $ do

--- a/test/NixShellBit/Sbox.hs
+++ b/test/NixShellBit/Sbox.hs
@@ -24,7 +24,7 @@ import System.Directory          (copyFile, createDirectory)
 import System.FilePath           ((</>))
 import Test.Utils                (silence, withEnv, withInput)
 
-import qualified Data.ByteString.Char8 as C
+import qualified Data.ByteString.Char8 as BS8
 import qualified Test.Sandbox as S
 
 
@@ -50,7 +50,7 @@ withSandbox =
             copyDirectoryRecursive silent "test/fixtures" (fixturesPath sand)
 
             _ <- withInput ["yes"] (silence configInit)
-            C.writeFile (xdgConfig </> "git/config") ""
+            BS8.writeFile (xdgConfig </> "git/config") ""
 
             -- configure sandbox Git user
             git_ ["config", "--global", "user.email", "nobody@example.com"]
@@ -58,7 +58,7 @@ withSandbox =
 
             -- setup remote project
             git_ ["init", "--quiet", "--template", "", remoteProj]
-            C.writeFile (remoteProj </> "VERSION") (C.pack initialVersion)
+            BS8.writeFile (remoteProj </> "VERSION") (BS8.pack initialVersion)
             git_ ["-C", remoteProj, "add", "VERSION"]
             git_ ["-C", remoteProj, "commit", "--quiet", "--message", "x"]
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,6 +11,7 @@ import Test.Hspec           (after_, before_, hspec)
 import Test.Sandbox         (sbPath, refresh)
 import Test.Utils           (withEnv)
 
+import qualified NixShellBit.ColumnSpec    as ColumnSpec
 import qualified NixShellBit.ConfigSpec    as ConfigSpec
 import qualified NixShellBit.GitSpec       as GitSpec
 import qualified NixShellBit.MainSpec      as MainSpec
@@ -34,6 +35,7 @@ main =
             [("XDG_CONFIG_HOME", Just $ xdgConfigPath sand)]
             $ hspec $ before_ (refresh sbox) $ after_ removeTempClones $
             do
+              ColumnSpec.spec
               ConfigSpec.spec sand
               GitSpec.spec sand
               MainSpec.spec sand

--- a/test/Test/Utils.hs
+++ b/test/Test/Utils.hs
@@ -27,8 +27,8 @@ import Test.Main          (ProcessResult, captureProcessResult, prExitCode,
 import Text.Regex.TDFA    ((=~))
 import UnliftIO.Exception (throwString)
 
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Char8 as C
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as E
 
@@ -81,7 +81,7 @@ maybeCapture action =
 
 withInput :: [String] -> IO a -> IO a
 withInput input =
-  withStdin (C.unlines (map C.pack input))
+  withStdin (BS8.unlines (map BS8.pack input))
 
 
 string :: ByteString -> String
@@ -95,8 +95,8 @@ colorStrip = go ""
     go acc xs = go (acc <> a) (dropSGR b)
       where
         -- SGR sequences begin with `ESC[` and end with `m`
-        (a, b) = B.breakSubstring "\ESC[" xs
-        dropSGR = B.drop 1 . B.dropWhile (/= 0x6d)
+        (a, b) = BS.breakSubstring "\ESC[" xs
+        dropSGR = BS.drop 1 . BS.dropWhile (/= 0x6d)
 
 
 infix 1 `shouldMatch`

--- a/test/integration
+++ b/test/integration
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p bats coreutils findutils gawk git gnugrep ncurses perl socat utillinux
+#! nix-shell -i bash -p bats coreutils findutils gawk git gnugrep ncurses perl socat
 
 set -eu
 


### PR DESCRIPTION
Implementing column functionality in Haskell frees us from calling out to an external `column` process and eliminates the dependency on util-linux. It was also really interesting to write.

Along the way, I added a `nix-shell-bit-minimal` package that provides `nix-shell-bit` but doesn't include Nix and Git as runtime dependencies. This is in the interest of reducing the closure size of the package a user has to install, and it's a safe assumption that they do in fact have Nix and Git already installed, given the nature of this tool.

However, because we're calling out to `git ls-remote` and leveraging some version sorting options that are not present in older Git versions, this could lead to breakage if a user with an older Git installation choses to install `nix-shell-bit-minimal` rather than the "full" package. For that reason, I'm treating the full package as the default until I've adjusted the `git ls-remote` call to be backwards compatible.