### PR TITLE
Minimal default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,12 @@ lint: default.nix
 .PHONY: nix-build
 nix-build: default.nix
 	@echo "Running nix-build"
-	@nix-build ./nix --attr full
-
-.PHONY: nix-build-minimal
-nix-build-minimal: default.nix
-	@echo "Running nix-build"
 	@nix-build ./nix --attr minimal
+
+.PHONY: nix-build-full
+nix-build-full: default.nix
+	@echo "Running nix-build"
+	@nix-build ./nix --attr full
 
 .PHONY: completions
 completions: default.nix
@@ -59,16 +59,16 @@ completions: default.nix
 
 .PHONY: install
 install: default.nix
-	@nix-env --install --file ./nix --attr full
-
-.PHONY: install-minimal
-install-minimal: default.nix
 	@nix-env --install --file ./nix --attr minimal
+
+.PHONY: install-full
+install-full: default.nix
+	@nix-env --install --file ./nix --attr full
 
 .PHONY: uninstall
 uninstall: default.nix
 	@nix-env --uninstall $(PROJECT_NAME)
-	@nix-env --uninstall $(PROJECT_NAME)-minimal
+	@nix-env --uninstall $(PROJECT_NAME)-full
 
 default.nix: $(PROJECT_NAME).cabal
 	@echo "Generating default.nix"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,3 @@ update nixpkgs revision
 ```sh
 make update-nixpkgs REV=bc94dcf500286495e3c478a9f9322debc94c4304
 ```
-
-## Todos
-
-- [ ] use conduit-extra

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -28,14 +28,14 @@ let
 
 in
   rec {
-    full = buildEnv {
+    minimal = pkg.overrideAttrs (old: rec {
       name = "nix-shell-bit";
+    });
+
+    full = buildEnv {
+      name = "nix-shell-bit-full";
       paths = [ pkg ] ++ runtimeDeps;
     };
-
-    minimal = pkg.overrideAttrs (old: rec {
-      name = "nix-shell-bit-minimal";
-    });
 
     dev = drv.env.overrideAttrs (old: rec {
       buildInputs = old.buildInputs ++ runtimeDeps ++ devUtils;


### PR DESCRIPTION
Now that we have a fallback strategy in place to allow `gitTaggedVersions` to work with older versions of git, we can reasonably make the minimal package (which assumes nix and git are already installed) the default.